### PR TITLE
Remove redundant 'copts' arguments by correctly defining the cc_library.

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -4,7 +4,6 @@ load(":macros.bzl", "src_target_test")
 cc_library(
     name = "catch-main",
     srcs = ["main.cpp"],
-    copts = ["-Itest/vendor/catch2"],
     deps = [
       "//test/vendor/catch2"
     ]

--- a/test/macros.bzl
+++ b/test/macros.bzl
@@ -4,7 +4,7 @@ def src_target_test(target_name):
     native.cc_test(
         name = target_name,
         srcs = [target_name + ".test.cpp"],
-        copts = ["-Itest/vendor/catch2/", "-Isrc/"],
+        copts = ["-Isrc/"],
         deps = [
             "//test/vendor/catch2",
             "catch-main",

--- a/test/vendor/catch2/BUILD
+++ b/test/vendor/catch2/BUILD
@@ -1,5 +1,7 @@
 cc_library(
     name = "catch2",
     hdrs = ["catch.hpp"],
-    visibility = ["//test:__pkg__"]
+    visibility = ["//test:__pkg__"],
+    # Yes, export includes to all dependencies!
+    includes = ["."],
 )


### PR DESCRIPTION
An improvement because you requested one in your blog post (http://martinsosic.com/cpp/bazel/catch2/2018/08/28/cpp-bazel-catch2.html). Otherwise a nice read! Also great choice of two great tools (catch and bazel).

Remove redundant 'copts' arguments by correctly defining the cc_library.

`catch` should be a library which exports the include path. Then, every dependency can include it as `catch.hpp`. The alternative would be to follow google-style-guide convention of having full paths to the header: `test/vendor/catch2/catch.hpp`. Manually declaring the copts to be `-Itest/vendor/catch2` is not the solution, IMO.